### PR TITLE
python 3.9 compatibility fix: normalized encoding names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,25 +17,25 @@ Usage
 
 Currently there are four codecs defined for variations of the PETSCII encoding:
 
-petscii-c64en-lc
+petscii_c64en_lc
     The English version of the Commodore 64 mixed-case character set
 
-petscii-c64en-uc
+petscii_c64en_uc
     The English version of the Commodore 64 upper-case/graphics character set
 
-petscii-vic20en-lc
+petscii_vic20en_lc
     The English version of the VIC-20 mixed-case character set
 
-petscii-vic20en-uc
+petscii_vic20en_uc
     The English version of the VIC-20 upper-case/graphics character set
 
 
 There are two codecs defined to handle the Screencode (POKE) encoding:
 
-screencode-c64-lc
+screencode_c64_lc
     Mixed-case mapping to screencodes (POKE) used by the Commodore 64 and Vic20
 
-screencode-c64-uc
+screencode_c64_uc
     Upper-case/graphics mapping to screencodes (POKE) used by the Commodore 64 and Vic20
 
 
@@ -45,7 +45,7 @@ with any of the encodings from the standard library::
     import cbmcodecs
 
 
-    with open('file.seq', encoding='petscii-c64en-lc') as f:
+    with open('file.seq', encoding='petscii_c64en_lc') as f:
         for line in f:
             print(line)
 

--- a/cbmcodecs/__init__.py
+++ b/cbmcodecs/__init__.py
@@ -24,16 +24,24 @@ from . import petscii_vic20en_uc
 from . import screencode_c64_lc
 from . import screencode_c64_uc
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 __all__ = []
 
 petscii_codecs = {
+    # backwards compatibility encoding names:
     'petscii-c64en-lc': petscii_c64en_lc.getregentry(),
     'petscii-c64en-uc': petscii_c64en_uc.getregentry(),
     'petscii-vic20en-lc': petscii_vic20en_lc.getregentry(),
     'petscii-vic20en-uc': petscii_vic20en_uc.getregentry(),
     'screencode-c64-lc': screencode_c64_lc.getregentry(),
-    'screencode-c64-uc': screencode_c64_uc.getregentry()
+    'screencode-c64-uc': screencode_c64_uc.getregentry(),
+    # normalized encoding names since python 3.9:
+    'petscii_c64en_lc': petscii_c64en_lc.getregentry(),
+    'petscii_c64en_uc': petscii_c64en_uc.getregentry(),
+    'petscii_vic20en_lc': petscii_vic20en_lc.getregentry(),
+    'petscii_vic20en_uc': petscii_vic20en_uc.getregentry(),
+    'screencode_c64_lc': screencode_c64_lc.getregentry(),
+    'screencode_c64_uc': screencode_c64_uc.getregentry()
 }
 
 

--- a/cbmcodecs/__init__.py
+++ b/cbmcodecs/__init__.py
@@ -8,12 +8,12 @@ The screencode mappings were written by hand by Irmen de Jong.
 
 The following encodings are defined by this package:
 
-petscii-c64en-lc - Mixed-case mapping used by the Commodore 64
-petscii-c64en-uc - Upper-case/graphics mapping used by the Commodore 64
-petscii-vic20en-lc - Mixed-case mapping used by the Commodore VIC-20
-petscii-vic20en-uc - Upper-case/graphics mapping used by the VIC-20
-screencode-c64-lc - Mixed-case mapping to screencodes (POKE) used by the Commodore 64 and Vic20
-screencode-c64-uc - Upper-case/graphics mapping to screencodes (POKE) used by the Commodore 64 and Vic20
+petscii_c64en_lc - Mixed-case mapping used by the Commodore 64
+petscii_c64en_uc - Upper-case/graphics mapping used by the Commodore 64
+petscii_vic20en_lc - Mixed-case mapping used by the Commodore VIC-20
+petscii_vic20en_uc - Upper-case/graphics mapping used by the VIC-20
+screencode_c64_lc - Mixed-case mapping to screencodes (POKE) used by the Commodore 64 and Vic20
+screencode_c64_uc - Upper-case/graphics mapping to screencodes (POKE) used by the Commodore 64 and Vic20
 """
 import codecs
 
@@ -24,7 +24,7 @@ from . import petscii_vic20en_uc
 from . import screencode_c64_lc
 from . import screencode_c64_uc
 
-__version__ = '0.2.2'
+__version__ = '0.2.1'
 __all__ = []
 
 petscii_codecs = {

--- a/cbmcodecs/petscii_c64en_lc.py
+++ b/cbmcodecs/petscii_c64en_lc.py
@@ -32,7 +32,7 @@ class StreamReader(Codec, codecs.StreamReader):
 
 def getregentry():
     return codecs.CodecInfo(
-        name='petscii-c64en-lc',
+        name='petscii_c64en_lc',
         encode=Codec().encode,
         decode=Codec().decode,
         incrementalencoder=IncrementalEncoder,

--- a/cbmcodecs/petscii_c64en_uc.py
+++ b/cbmcodecs/petscii_c64en_uc.py
@@ -32,7 +32,7 @@ class StreamReader(Codec, codecs.StreamReader):
 
 def getregentry():
     return codecs.CodecInfo(
-        name='petscii-c64en-uc',
+        name='petscii_c64en_uc',
         encode=Codec().encode,
         decode=Codec().decode,
         incrementalencoder=IncrementalEncoder,

--- a/cbmcodecs/petscii_vic20en_lc.py
+++ b/cbmcodecs/petscii_vic20en_lc.py
@@ -32,7 +32,7 @@ class StreamReader(Codec, codecs.StreamReader):
 
 def getregentry():
     return codecs.CodecInfo(
-        name='petscii-vic20en-lc',
+        name='petscii_vic20en_lc',
         encode=Codec().encode,
         decode=Codec().decode,
         incrementalencoder=IncrementalEncoder,

--- a/cbmcodecs/petscii_vic20en_uc.py
+++ b/cbmcodecs/petscii_vic20en_uc.py
@@ -32,7 +32,7 @@ class StreamReader(Codec, codecs.StreamReader):
 
 def getregentry():
     return codecs.CodecInfo(
-        name='petscii-vic20en-uc',
+        name='petscii_vic20en_uc',
         encode=Codec().encode,
         decode=Codec().decode,
         incrementalencoder=IncrementalEncoder,

--- a/cbmcodecs/screencode_c64_lc.py
+++ b/cbmcodecs/screencode_c64_lc.py
@@ -32,7 +32,7 @@ class StreamReader(Codec, codecs.StreamReader):
 
 def getregentry():
     return codecs.CodecInfo(
-        name='screencode-c64-lc',
+        name='screencode_c64_lc',
         encode=Codec().encode,
         decode=Codec().decode,
         incrementalencoder=IncrementalEncoder,

--- a/cbmcodecs/screencode_c64_uc.py
+++ b/cbmcodecs/screencode_c64_uc.py
@@ -32,7 +32,7 @@ class StreamReader(Codec, codecs.StreamReader):
 
 def getregentry():
     return codecs.CodecInfo(
-        name='screencode-c64-uc',
+        name='screencode_c64_uc',
         encode=Codec().encode,
         decode=Codec().decode,
         incrementalencoder=IncrementalEncoder,

--- a/tests/codec_test.py
+++ b/tests/codec_test.py
@@ -4,7 +4,7 @@ import unittest
 
 class TestC64Codecs(unittest.TestCase):
     def test_lowercase(self):
-        codec = "petscii-c64en-lc"
+        codec = "petscii_c64en_lc"
         self.assertEqual(b"HELLO \xd7\xcf\xd2\xcc\xc4 123 @!\x5c", "hello WORLD 123 @!£".encode(codec))
         self.assertEqual(b"\x12", "\uf11a".encode(codec))  # reversevid
         self.assertEqual(b"\xfa", "✓".encode(codec))
@@ -14,7 +14,7 @@ class TestC64Codecs(unittest.TestCase):
             "♥".encode(codec)
 
     def test_uppercase(self):
-        codec = "petscii-c64en-uc"
+        codec = "petscii_c64en_uc"
         self.assertEqual(b"HELLO 123 @!\x5c", "HELLO 123 @!£".encode(codec))
         self.assertEqual(b"\x12", "\uf11a".encode(codec))  # reversevid
         self.assertEqual(b"\xd3", "♥".encode(codec))
@@ -23,7 +23,7 @@ class TestC64Codecs(unittest.TestCase):
             "✓".encode(codec)
 
     def test_screencodes_lowercase(self):
-        codec = "screencode-c64-lc"
+        codec = "screencode_c64_lc"
         self.assertEqual(b"\x08\x05\x0c\x0c\x0f\x20\x57\x4f\x52\x4c\x44\x20\x31\x32\x33\x20\x00\x21\x1c",
                          "hello WORLD 123 @!£".encode(codec))
         self.assertEqual(b"\x7a", "✓".encode(codec))
@@ -33,7 +33,7 @@ class TestC64Codecs(unittest.TestCase):
             "π".encode(codec)
 
     def test_screencodes_uppercase(self):
-        codec = "screencode-c64-uc"
+        codec = "screencode_c64_uc"
         self.assertEqual(b"\x17\x0f\x12\x0c\x04\x20\x31\x32\x33\x20\x00\x21\x1c", "WORLD 123 @!£".encode(codec))
         self.assertEqual(b"\x53", "♥".encode(codec))
         self.assertEqual(b"\x5e", "π".encode(codec))
@@ -45,7 +45,7 @@ class TestC64Codecs(unittest.TestCase):
 
 class TestVic20Codecs(unittest.TestCase):
     def test_lowercase(self):
-        codec = "petscii-vic20en-lc"
+        codec = "petscii_vic20en_lc"
         self.assertEqual(b"HELLO \xd7\xcf\xd2\xcc\xc4 123 @!\x5c", "hello WORLD 123 @!£".encode(codec))
         self.assertEqual(b"\xfa", "✓".encode(codec))
         with self.assertRaises(UnicodeEncodeError):
@@ -56,7 +56,7 @@ class TestVic20Codecs(unittest.TestCase):
             "\uf11a".encode(codec)  # reversevid not supported on vic20
 
     def test_uppercase(self):
-        codec = "petscii-vic20en-uc"
+        codec = "petscii_vic20en_uc"
         self.assertEqual(b"HELLO 123 @!\x5c", "HELLO 123 @!£".encode(codec))
         self.assertEqual(b"\xd3", "♥".encode(codec))
         self.assertEqual(b"\xff", "π".encode(codec))


### PR DESCRIPTION
Since Python 3.9 apparently '-' in codec names are normalized into '_'.  So these names had to be added to the lookup table as well